### PR TITLE
Add persistence to search params and filters in /challenges

### DIFF
--- a/src/func/localStorageFunctions.js
+++ b/src/func/localStorageFunctions.js
@@ -1,0 +1,44 @@
+/**
+ * Keys used for localStorage.
+ */
+export const storageKeys = {
+  challengeFilters: "challenge-filters",
+  challengeSearch: "challenge-search"
+}
+
+/**
+ * Get the JSON parsed value by key from localStorage. If no value is found,
+ * a default value can optionally be used as the return.
+ * @param {string} key localStorage key
+ * @param {any} defaultValue default value to return if no value was found
+ * @returns {any}
+ */
+export function getStorage(key, defaultValue) {
+  let value = JSON.parse(localStorage.getItem(key));
+  if (value == null) value = defaultValue ?? undefined;
+  return value;
+}
+
+/**
+ * Sets the JSON stringified value of key into localStorage.
+ * @param {string} key
+ * @param {any} value
+ */
+export function setStorage(key, value) {
+  localStorage.setItem(key, JSON.stringify(value));
+}
+
+/**
+ * Removes the JSON value associated with key from localStorage.
+ * @param {string} key
+ */
+export function removeStorage(key) {
+  localStorage.removeItem(key);
+}
+
+/**
+ * Clears all values from localStorage. Be careful using this. ❤️
+ */
+export function clearStorage() {
+  localStorage.clear();
+}

--- a/src/module/Challenges.js
+++ b/src/module/Challenges.js
@@ -341,7 +341,6 @@ class Challenges extends Component {
                     "type": this.filter.type,
                     "gamemode": this.filter.gamemode
                 }
-                setStorage(storageKeys.challengeFilters, this.filter);
 
                 break;
             case "type":
@@ -350,7 +349,6 @@ class Challenges extends Component {
                     "category": this.filter.category,
                     "gamemode": this.filter.gamemode
                 }
-                setStorage(storageKeys.challengeFilters, this.filter);
 
                 break;
             default:
@@ -359,10 +357,10 @@ class Challenges extends Component {
                     "type": this.filter.type,
                     "category": this.filter.category
                 }
-                setStorage(storageKeys.challengeFilters, this.filter);
 
                 break;
         }
+        setStorage(storageKeys.challengeFilters, this.filter);
         this.showChallenges(window.JSONPREQUEST)
     }
 


### PR DESCRIPTION
This PR attempts to solve issue #90.  (✿ᴗ͈ˬᴗ͈)⁾⁾
### Changes
* Add helper functions for saving data with `localStorage`.
* Add data persistence to `/challenges` page for search and filters!
### Notes
I tried following the current coding style for this project but I wasn't sure about the semicolons (I see some lines have semicolons while others do not). Sorries. >.<