### PR TITLE
Make text contrast for "None" and "Unranked" styles easier to see for accessibility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -123,7 +123,7 @@ button {
 
 .UNRANKED,
 .NONE {
-  --type: black;
+  --type: var(--light3);
   --url: url('https://lolcdn.darkintaqt.com/s/_-none')
 }
 


### PR DESCRIPTION
### Changes
* Use the `light3` grey color instead of black for `.UNRANKED, .NONE`.

![image](https://user-images.githubusercontent.com/87099578/218898680-97030fc6-6ae7-4a66-af38-d5f12306f464.png)
Attempt to solve issue #138. Not sure what color to use so I went with one of the default UI colors that I think blends nicely. :3

