### PR TITLE
Migrate titles page

### DIFF
--- a/pages/titles.js
+++ b/pages/titles.js
@@ -1,3 +1,126 @@
-export default function Titles() {
-   return <span>Titles</span>;
+import "typedef";
+import Head from "next/head";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import ChallengeService from "challenges/services/ChallengeService";
+import ContentService from "challenges/services/ContentService";
+import css from "styles/titles.module.scss";
+import filterCss from "styles/filter.module.scss";
+import { storageKeys, getStorage, setStorage } from "utils/localStorageFunctions";
+
+/**
+ * @typedef TitlesProps
+ * @type {Object}
+ * @property {Array.<TitleDto>} titles
+ */
+
+/**
+ * @param {TitlesProps} props 
+ */
+export default function Titles({titles}) {
+   const [ searchList, setSearchList ] = useState(titles);
+   const [ search, setSearch ] = useState("");
+
+   // Local storage can only be called within useEffect which happens client-side.
+   useEffect(() => {
+      const savedSearch = getStorage(storageKeys.titleSearch, "");
+      // Load previous search query from local storage.
+      if (savedSearch !== "") {
+         handleChallengeSearch(savedSearch, titles, setSearchList);
+         setSearch(savedSearch);
+      }
+   }, [titles, search]);
+
+   return <div className={"object1000"}>
+      <Head>
+         <title>All Challenges Titles - Overview</title>
+      </Head>
+      
+      <h1 className={css.heading}>All titles</h1>
+      <p className={css.subheading}>A list of all League of Legends Title Challenges and how to achieve them</p>
+      <input 
+      className={filterCss.input}
+      type="search" 
+      list="items" 
+      placeholder="Search for challenge titles" 
+      defaultValue={search}
+      spellCheck={false}
+      // We need these three event handlers to deal with oddities across Chrome and Firefox. ૮(˶╥︿╥)ა
+      onChange={(e) => handleChallengeSearch(e.target.value, titles, setSearchList)}
+      onKeyUp={(e) => handleChallengeSearch(e.target.value, titles, setSearchList)}
+      onInput={(e) => handleChallengeSearch(e.target.value, titles, setSearchList)}/>
+      
+      <datalist id="items">
+         {/* Add challenge titles to datalist for native HTML searching options! (*´▽`*)❀ */}
+         {titles.map((title) => <option key={title.cid} value={title.title}/> )}
+      </datalist>
+
+      <div className={css.titles}>
+         <TitleList titles={searchList}/>
+      </div>
+   </div>;
+}
+
+/**
+ * @typedef TitleListProps
+ * @type {Object}
+ * @property {Array.<TitleDto>} titles
+ */
+
+/**
+ * @param {TitleListProps} props 
+ */
+function TitleList({titles}) {
+   const contentService = new ContentService();
+
+   const challengeTitles = titles.map((title) => {
+      const iconLink = contentService.getChallengeTokenIcon(title.icon, title.type);
+
+      return <a 
+      key={title.cid}
+      href={"/challenge/" + title.cid} 
+      className={`${css.title} ${title.type} clearfix`}
+      challengeid={title.cid}>
+         <span>
+            <Image 
+            height={45}
+            width={45}
+            src={iconLink}
+            placeholdersrc={"https://cdn.darkintaqt.com/lol/static/missing/item.png"}
+            alt={`${title.title}'s icon`}
+            loading="lazy"
+            />
+         </span>
+         
+         <h2>{title.title}<br/><span data-nosnippet>{title.percentile}%</span></h2>
+         <p>Reach {title.type} tier in {title.challenge}<br></br>{title.description}<br /><br /><i>Need {title.threshold}</i></p>
+
+      </a>;
+   });
+
+   return challengeTitles;
+}
+
+/**
+ * Search challenge titles and filter if title includes query. Case in-sensitive.
+ * @param {string} value 
+ * @param {Array.<TitleDto>} titles 
+ * @param {Function} setSearchList 
+ */
+function handleChallengeSearch(value, titles, setSearchList) {
+   // Filter challenge titles that include the search value (case-insensitive)
+   const query = titles.filter((title) => title.title.toLowerCase().includes(value.toLowerCase()));
+   setStorage(storageKeys.titleSearch, value);
+   setSearchList([...query]);
+}
+
+export async function getServerSideProps() {
+   const challengeService = new ChallengeService();
+   const titles = await challengeService.listTitles();
+
+   return {
+      props: {
+         titles
+      }
+   };
 }

--- a/services/ChallengeService.js
+++ b/services/ChallengeService.js
@@ -1,0 +1,48 @@
+import "typedef";
+import requests from "challenges/utils/requestFunctions";
+
+/**
+ * Represents a service for providing challenge related data.
+ */
+export default class ChallengeService {
+  static baseUrl = "https://challenges.darkintaqt.com/api";
+
+  constructor() { 
+    this.list = this.list.bind(this);
+    this.listTitles = this.listTitles.bind(this);
+    this.getById = this.getById.bind(this);
+
+    const { getJson } = requests(ChallengeService.baseUrl);
+    this.getJson = getJson;
+  }
+
+  /**
+   * Get the current list of challenges by region and language.
+   * @param {string} region e.g. "na1", "euw1"...
+   * @param {string} lang e.g. "en", "de"...
+   * @returns {Promise<Array.<ChallengeDto>>} Challenges
+   */
+  async list(region, lang) {
+    const challenges = await this.getJson(`/dynamic-data/serve?region=${region}&lang=${lang}`);
+    return challenges;
+  }
+
+  /**
+   * Get the current list of challenge titles.
+   * @returns {Promise<Array.<TitleDto>>} Titles
+   */
+  async listTitles() {
+    const titles = await this.getJson("/v2/t/");
+    return titles;
+  }
+
+  /**
+   * Get the challenge associated with numerical id.
+   * @param {number} id 
+   * @returns {Promise<any>} Challenge
+   */
+  async getById(id) {
+    const challenge = await this.getJson(`/v5/c/?id=${id}`);
+    return challenge;
+  }
+}

--- a/services/ContentService.js
+++ b/services/ContentService.js
@@ -1,0 +1,25 @@
+import "typedef";
+
+/**
+ * Represents a service for providing data from CDN.
+ */
+export default class ContentService {
+  static cdnUrl = "https://lolcdn.darkintaqt.com/cdn";
+
+  constructor() {
+    this.getChallengeTokenIcon = this.getChallengeTokenIcon.bind(this);
+  }
+
+  /**
+   * Get the link of a challenge token icon by id. Tier type can optionally be 
+   * passed for tier token icon (Diamond, Master, etc).
+   * @param {number} id 
+   * @param {string} type e.g. "diamond", "master"... case in-sensitive
+   * @returns {string}
+   */
+  getChallengeTokenIcon(id, type) {
+    let link = `${ContentService.cdnUrl}/np-token/${id}`;
+    if (type != null) link = `${link}/${type.toLowerCase()}`;
+    return encodeURI(link);
+  }
+}

--- a/styles/filter.module.scss
+++ b/styles/filter.module.scss
@@ -1,0 +1,192 @@
+.filter {
+  width: 250px;
+  float: left;
+  overflow: hidden;
+
+}
+
+.displayMode {
+  width: 100%;
+  float: left;
+  margin-bottom: 10px;
+
+  button img {
+    height: 24px;
+    width: 25px;
+  }
+
+  &>button {
+    border: none;
+    background-color: var(--dark0);
+    color: var(--light2);
+    height: 40px;
+    width: 40px;
+    cursor: pointer;
+    border-radius: 50%;
+    float: left;
+    margin-right: 10px;
+    font-size: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+// TODO
+// Syntax error: Selector "button > span" is not pure (pure selectors must contain at least one local class or id)
+
+// button>span {
+//   display: block;
+//   float: right;
+//   font-size: .7rem;
+//   font-weight: bold;
+//   color: white !important;
+//   padding: .15rem 5px;
+//   box-shadow: 0 0 5px var(--selected);
+//   background-color: var(--selected);
+//   border-radius: 5px;
+//   margin-left: 5px;
+// }
+
+button.cmodefalse.modefalse,
+button.cmodetrue.modetrue,
+button.mastertrue,
+button.pointstrue {
+  background-color: var(--dark2);
+  color: white
+}
+
+@media only screen and (min-height:800px) {
+  .filter {
+      position: sticky;
+      top: 60px;
+  }
+}
+
+.input {
+  width: 80%;
+  margin: 10px 10%;
+  background: var(--dark2);
+  color: white;
+  padding: 8px 20px;
+  box-sizing: border-box;
+  font-size: 1rem;
+  outline: none;
+  border: 1px solid transparent;
+  border-radius: 20px;
+
+  &:focus {
+    border-color: var(--selected);
+    box-shadow: 0 0 5px var(--selected);
+  }
+
+  p.info {
+    font-size: 1rem;
+    width: 100%;
+    color: white;
+    margin-bottom: 10px;
+    display: none;
+    text-align: center;
+  }
+
+  .selectors {
+    width: calc(100% - 20px);
+    margin: 15px 10px 10px;
+    box-sizing: border-box;
+    padding: 0 10px 10px;
+    border-radius: 8px;
+    overflow: hidden;
+
+    .category {
+      width: 100%;
+      margin-bottom: 20px;
+      float: left;
+      overflow: hidden;
+
+      &>button {
+        font-size: 1rem;
+        white-space: nowrap;
+        color: rgb(200, 200, 200);
+        background-color: var(--dark0);
+        margin: 5px 0;
+        border-radius: 10px;
+        padding: 5px 10px;
+        border: 2px solid transparent;
+        cursor: pointer;
+        display: block;
+        width: 100%;
+        text-align: left;
+        transition: 0.25s padding-left;
+
+        &:hover {
+          color: white;
+          background-color: var(--dark1);
+        }
+
+        &>i {
+          width: 1rem;
+          height: 1rem;
+          font-size: 1rem;
+          float: left;
+          color: white !important;
+          text-align: center;
+          margin-right: 5px;
+        }
+
+        &>img {
+          width: 1rem;
+          height: 1rem;
+          float: left;
+          margin-right: 5px;
+        }
+
+        .selected {
+          /* color: var(--selected);
+          box-shadow: 0 0 3px var(--selected);
+          border: 2px solid var(--selected); */
+          background-color: var(--dark2);
+          color: white;
+          padding-left: 20px;
+        }
+      }
+
+      .cheading {
+        font-size: 0.8rem;
+        color: white;
+        width: 100%;
+        text-align: left;
+        font-weight: bold;
+      }
+    }
+  }
+}
+
+@media only screen and (max-width:1050px) {
+  .filter {
+      position: relative !important;
+      width: 100%;
+      top: 0;
+
+      .selectors .category {
+        width: calc(calc(1/3) * 0.9 * 100%);
+        margin: 0 calc(calc(1/3) * 0.05 * 100%);
+        float: left;
+
+        &>button {
+          background-color: var(--dark1);
+
+          &.selected {
+            border: 2px solid var(--selected);
+            padding-left: 10px;
+          }
+        }
+      }
+  }
+}
+
+@media only screen and (max-width:650px) {
+  .filter .selectors .category {
+      width: 100%;
+      margin: 0;
+  }
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -4,6 +4,8 @@ body {
    margin: 0;
    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
       Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  
+   overflow-x: hidden;
 }
 
 a {

--- a/styles/layout.module.scss
+++ b/styles/layout.module.scss
@@ -2,7 +2,7 @@
 
 .wrapper {
    width: 100vw;
-   height: 100vh;
+   min-height: 100vh;
    background: $dark1;
 
    position: relative;
@@ -12,13 +12,12 @@
    position: relative;
    align-items: stretch;
 
-
    .contentWrapper {
-
       flex: 1;
       background: $dark0;
       min-height: 100vh;
 
       position: relative;
+
    }
 }

--- a/styles/titles.module.scss
+++ b/styles/titles.module.scss
@@ -1,0 +1,109 @@
+.heading {
+  padding: 20px 0 10px;
+  font-size: 2rem;
+  color: white;
+}
+
+.subheading {
+  font-size: 1rem;
+  color: var(--light2);
+  padding-bottom: 10px;
+}
+
+.titles {
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+}
+
+a.title {
+  width: 320px;
+  box-sizing: border-box;
+  border: 2px solid var(--type);
+  padding: 5px;
+  margin: 10px 5px;
+  background: var(--dark1);
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  cursor: pointer;
+  border-radius: 5px;
+  position: relative;
+  overflow: visible;
+}
+
+.title>span {
+  position: absolute;
+  height: 45px;
+  width: 45px;
+  display: block;
+  margin: -15px 0 0 -15px;
+  border-radius: 50%;
+  z-index: 1;
+  left: 0;
+  top: 0;
+}
+
+.titles .loading {
+  font-size: 1rem;
+  margin: 40px;
+  font-weight: bold;
+  text-align: center;
+  color: white;
+}
+
+.title::before {
+  height: 35px;
+  width: 35px;
+  margin: -10px 0 0 -10px;
+  content: '';
+  z-index: 0;
+  box-shadow: 0 0 15px 5px var(--type);
+  position: absolute;
+  left: 0;
+  top: 0;
+  border-radius: 50%;
+}
+
+.title>h2 {
+  color: white;
+  font-size: 1.2rem;
+  flex: 0 0 45%;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.title>h2>span {
+  font-size: .8rem;
+  font-weight: normal;
+  color: var(--light2);
+}
+
+.title>p:last-of-type>span {
+  font-weight: bold;
+}
+
+.title>p {
+  color: var(--light2);
+  font-size: 0.8rem;
+  width: 60%;
+  min-height: 80px;
+  border-left: 1px solid var(--type);
+  box-sizing: border-box;
+  padding: 10px;
+  float: left;
+}
+
+.disclaimer {
+  color: white;
+  font-size: 0.8rem;
+  margin: 20px 0;
+}
+
+@media only screen and (max-width:1050px) {
+
+  .titles {
+      padding: 0 20px;
+  }
+
+}

--- a/typedef.js
+++ b/typedef.js
@@ -1,0 +1,58 @@
+  /**
+   * @typedef StatsDto
+   * @type {Object}
+   * @property {number} CHALLENGER 
+   * @property {number} BRONZE
+   * @property {number} GOLD
+   * @property {number} MASTER 
+   * @property {number} GRANDMASTER 
+   * @property {number} SILVER 
+   * @property {number} DIAMOND
+   * @property {number} PLATINUM
+   * @property {number} IRON
+   */
+
+  /**
+   * @typedef TranslationDto
+   * @type {Object}
+   * @property {string} description
+   * @property {string} name 
+   * @property {string} shortDescription
+   */
+
+  /**
+   * @typedef TagsDto
+   * @type {Object} 
+   * @property {string} isCapstone 
+   * @property {string} source
+   */
+
+  /**
+   * @typedef ChallengeDto
+   * @type {Object}
+   * @property {number} id
+   * @property {string} state
+   * @property {boolean} leaderboard 
+   * @property {Array.<StatsDto>} thresholds
+   * @property {TranslationDto} translation
+   * @property {boolean} reversed
+   * @property {Array.<number>} queueIds 
+   * @property {TagsDto} tags 
+   * @property {string} parent 
+   * @property {string} parentCategory 
+   * @property {Array.<StatsDto>} percentiles
+   * @property {Array.<number>} leaderboardThresholds
+   */
+
+  /**
+   * @typedef TitleDto
+   * @type {Object}
+   * @property {string} type
+   * @property {string} title
+   * @property {number} percentile
+   * @property {number} icon 
+   * @property {string} challenge 
+   * @property {string} description 
+   * @property {number} threshold 
+   * @property {string} cid
+   */

--- a/utils/localStorageFunctions.js
+++ b/utils/localStorageFunctions.js
@@ -3,7 +3,8 @@
  */
 export const storageKeys = {
    challengeFilters: "challenge-filters",
-   challengeSearch: "challenge-search"
+   challengeSearch: "challenge-search",
+   titleSearch: "title-search"
 };
 
 /**

--- a/utils/requestFunctions.js
+++ b/utils/requestFunctions.js
@@ -1,0 +1,34 @@
+/**
+ * Returns curried request functions that uses base url prepended.
+ * @param {string} baseUrl 
+ * @returns 
+ */
+export default function requests(baseUrl) {
+  /**
+   * Get JSON representation of response data. Returns undefined if response code
+   * was not in the 200-299 range.
+   * @param {string} url 
+   * @returns {any}
+   */
+  const getJson = async (url) => {
+    const res = await getResponse(url);
+
+    let data = undefined;
+    if (res.ok) {
+      data = await res.json();
+    }
+    return data;
+  };
+
+  /**
+   * Get the raw response using appended encoded url.
+   * @param {string} url 
+   * @returns {any}
+   */
+  const getResponse = async (url) => {
+    const res = await fetch(encodeURI(baseUrl + url));
+    return res;
+  };
+
+  return { getJson, getResponse };  
+}


### PR DESCRIPTION
### Changes
- Add helper functions and services for getting challenge/static related data.
- Add shared file with JSDoc typedefs for intellisense and doc stuffsies.
- Migrate titles page into Next.js.
- Migrate module stylesheets (filter and titles).

Whewie.  (づ ᴗ _ᴗ)づ

I also added the ability to search the challenge titles for the page (since it should be preloaded). The search is saved as well.  :3 

### What I have encountered but not added or may be missing
- i18n translations (not sure how to carry that over >w<)
- request caching
- Challenges page (so clicking on the challenge title leads to a `404` for now)

